### PR TITLE
updates maintainers

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,8 +6,11 @@
   </description>
 
   <author>Michael Ferguson</author>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>BSD</license>
   <url>http://ros.org/wiki/power_msgs</url>


### PR DESCRIPTION
Listed multiple individual maintainers and also included the internal
mailing list to ensure the load is distributed in the event of build
failures.